### PR TITLE
refactored examples/ar/hit-test

### DIFF
--- a/examples/ar/hit_test/index.html
+++ b/examples/ar/hit_test/index.html
@@ -6,173 +6,39 @@
     <script>window.debug = true;</script>
     <script src='../../../vendor/aframe-v0.7.1.js'></script>
     <script src='../../../dist/aframe-xr.js'></script>
-    <script>
-        AFRAME.registerComponent('hit-test', {
-        init: function () {
-          if (!this.el.isScene) {
-            console.warn('Fog component can only be applied to <a-scene>');
-            return;
-          }
-          this.tapData = null;
-          // an array of info that we'll use in _handleFrame to update the nodes using anchors
-          this.anchoredNodes = [] // { XRAnchorOffset, Three.js Object3D }
-
-          this.bindMethods();
-          this.addDOMEls();
-          this.scene = document.querySelector('a-scene');
-          this.scene.addEventListener('xrInitialized', this.xrInitialized);
-          this.scene.addEventListener('realityChanged', this.realityChanged);
-        },
-        addDOMEls: function () {
-          var title = document.createElement('div');
-          title.style.position = 'absolute';
-          title.style.top = '30px';
-          title.style.fontFamily = 'Arial, Helvetica, sans-serif';
-          title.style.fontSize = '16px';
-          title.style.fontWeight = 'bold';
-          title.style.zIndex = 10;
-          title.style.width = '100%';
-          title.style.textAlign = 'center';
-          title.innerHTML = 'Find anchors by searching on tap events.';
-          document.body.appendChild(title);
-
-          this.alertMessage = document.createElement('div');
-          this.alertMessage.style.position = 'absolute';
-          this.alertMessage.style.bottom = '50px';
-          this.alertMessage.style.fontFamily = 'Arial, Helvetica, sans-serif';
-          this.alertMessage.style.fontSize = '24px';
-          this.alertMessage.style.fontWeight = 'bold';
-          this.alertMessage.style.zIndex = 10;
-          this.alertMessage.style.width = '100%';
-          this.alertMessage.style.textAlign = 'center';
-          document.body.appendChild(this.alertMessage);
-        },
-        bindMethods: function (){
-          this.xrInitialized = this.xrInitialized.bind(this);
-          this.realityChanged = this.realityChanged.bind(this);
-          this.updateFrame = this.updateFrame.bind(this);
-          this.onTouchStart = this.onTouchStart.bind(this);
-        },
-        xrInitialized: function () {
-          this.scene.removeEventListener('xrInitialized', this.xrInitialized);
-          this.xrIsInit = true;
-          // normalized device coordinates position
-          this.normalizedCoordinatedPositionPointer = new THREE.Vector2();
-          //Screen coordinates normalized to -1..1 (0,0 is at center and 1,1 is at top right)
-          this.coordinatesToFindAnchors = new THREE.Vector2(0.5, 0.5);
-          window.addEventListener('touchstart', this.onTouchStart);
-
-          if (this.isNotStartedYet) {
-            this.start();
-          }
-        },
-        realityChanged: function (data) {
-          if (data.detail === 'ar') {
-            if (AFRAME.scenes[0].systems.xr.supportAR) {
-              if (this.xrIsInit) {
-                this.start();
-              } else {
-                this.isNotStartedYet = true;
-              }
-            }
-          }
-        },
-        start: function () {
-          this.scene.addEventListener('updateFrame', this.updateFrame);
-        },
-        onTouchStart: function (ev) {
-          if (!ev.touches || ev.touches.length === 0) {
-            console.error('No touches on touch event', ev);
-            return
-          }
-          this.tapData = [
-            ev.touches[0].clientX / window.innerWidth,
-            ev.touches[0].clientY / window.innerHeight
-          ];
-        },
-        /*
-        Add a node to the scene and keep its pose updated using the anchorOffset
-        */
-        addAnchoredNode: function (anchorOffset, node) {
-          this.anchoredNodes.push({
-            anchorOffset: anchorOffset,
-            node: node
-          });
-          this.scene.appendChild(node);
-        },
-        /*
-        Get the anchor data from the frame and use it and the anchor offset to update the pose of the node, this must be an Object3D
-        */
-        updateNodeFromAnchorOffset: function (frame, node, anchorOffset) {
-          var anchor = frame.getAnchor(anchorOffset.anchorUID);
-          if (anchor === null) {
-            return;
-          }
-          var anchorMatrix = new THREE.Matrix4().fromArray(anchorOffset.getOffsetTransform(anchor.coordinateSystem));
-          var positionVec3 = new THREE.Vector3().setFromMatrixPosition(anchorMatrix);
-
-          node.setAttribute('position', {
-            x: positionVec3.x,
-            y: positionVec3.y,
-            z: positionVec3.z
-          });
-
-          var rotationQuat = new THREE.Quaternion().setFromRotationMatrix(anchorMatrix);
-          var rotationVec3 = new THREE.Vector3().applyQuaternion(rotationQuat);
-
-          node.setAttribute('rotation', {
-            x: rotationVec3.x,
-            y: rotationVec3.y,
-            z: rotationVec3.z
-          });
-        },
-        createEntity: function () {
-          var newEl = document.createElement('a-entity');
-          newEl.setAttribute('geometry', {
-            primitive: 'box',
-            width: 0.1,
-            height: 0.1,
-            depth: 0.1
-          });
-
-          newEl.setAttribute('material', {
-            shader: 'standard',
-            transparent: true,
-            opacity: 0.45,
-            fog: false,
-            color: '#ffcc00'
-          });
-
-          return newEl;
-        },
-        updateFrame: function (data) {
-          var frame = data.detail;
-          if (this.tapData !== null) {
-            var x = this.tapData[0];
-            var y = this.tapData[1];
-            this.tapData = null;
-            var self = this;
-            data.detail.findAnchor(x,y).then(function (anchorOffset) {
-              if (anchorOffset === null){
-                self.alertMessage.innerHTML = 'miss';
-              } else {
-                self.alertMessage.innerHTML = 'hit';
-                self.addAnchoredNode(anchorOffset, self.createEntity());
-              }
-            }).catch(function (err) {
-              console.error('Error in hit test', err);
-            });
-          }
-          // Update anchored node positions in the scene graph
-          for (var i = 0; i < this.anchoredNodes.length; i++) {
-            this.updateNodeFromAnchorOffset(frame, this.anchoredNodes[i].node, this.anchoredNodes[i].anchorOffset);
-          }
-        }
-      });
-      </script>
+    <script src='../../lib/hit-test.js'></script>
   </head>
   <body>
     <a-scene hit-test>
     </a-scene>
+
+    <script>
+      var scene = AFRAME.scenes[0];
+
+      var newObject = function(data) {
+        var entity = data.detail;
+
+        entity.setAttribute('geometry', {
+          primitive: 'box',
+          width: 0.1,
+          height: 0.1,
+          depth: 0.1
+        });
+
+        entity.setAttribute('material', {
+          shader: 'standard',
+          transparent: true,
+          opacity: 0.45,
+          fog: false,
+          color: '#ffcc00'
+        });     
+
+        scene.appendChild(entity);
+      }
+
+      scene.addEventListener('newAnchoredEntity', newObject);
+    </script>
   </body>
 </html>
+
+

--- a/examples/lib/hit-test.js
+++ b/examples/lib/hit-test.js
@@ -1,0 +1,111 @@
+AFRAME.registerComponent('hit-test', {
+    init: function () {
+      if (!this.el.isScene) {
+        console.warn('Fog component can only be applied to <a-scene>');
+        return;
+      }
+      this.tapData = null;
+
+      this.bindMethods();
+      this.addDOMEls();
+      this.scene = this.el.sceneEl;
+      this.scene.addEventListener('xrInitialized', this.xrInitialized);
+      this.scene.addEventListener('realityChanged', this.realityChanged);
+    },
+    addDOMEls: function () {
+      var title = document.createElement('div');
+      title.style.position = 'absolute';
+      title.style.top = '30px';
+      title.style.fontFamily = 'Arial, Helvetica, sans-serif';
+      title.style.fontSize = '16px';
+      title.style.fontWeight = 'bold';
+      title.style.zIndex = 10;
+      title.style.width = '100%';
+      title.style.textAlign = 'center';
+      title.innerHTML = 'Find anchors by searching on tap events.';
+      document.body.appendChild(title);
+
+      this.alertMessage = document.createElement('div');
+      this.alertMessage.style.position = 'absolute';
+      this.alertMessage.style.bottom = '50px';
+      this.alertMessage.style.fontFamily = 'Arial, Helvetica, sans-serif';
+      this.alertMessage.style.fontSize = '24px';
+      this.alertMessage.style.fontWeight = 'bold';
+      this.alertMessage.style.zIndex = 10;
+      this.alertMessage.style.width = '100%';
+      this.alertMessage.style.textAlign = 'center';
+      document.body.appendChild(this.alertMessage);
+    },
+    bindMethods: function (){
+      this.xrInitialized = this.xrInitialized.bind(this);
+      this.realityChanged = this.realityChanged.bind(this);
+      this.updateFrame = this.updateFrame.bind(this);
+      this.onTouchStart = this.onTouchStart.bind(this);
+    },
+    xrInitialized: function () {
+      this.scene.removeEventListener('xrInitialized', this.xrInitialized);
+      this.xrIsInit = true;
+      // normalized device coordinates position
+      this.normalizedCoordinatedPositionPointer = new THREE.Vector2();
+      //Screen coordinates normalized to -1..1 (0,0 is at center and 1,1 is at top right)
+      this.coordinatesToFindAnchors = new THREE.Vector2(0.5, 0.5);
+      window.addEventListener('touchstart', this.onTouchStart);
+
+      if (this.isNotStartedYet) {
+        this.start();
+      }
+    },
+    realityChanged: function (data) {
+      if (data.detail === 'ar') {
+        if (AFRAME.scenes[0].systems.xr.supportAR) {
+          if (this.xrIsInit) {
+            this.start();
+          } else {
+            this.isNotStartedYet = true;
+          }
+        }
+      }
+    },
+    start: function () {
+      this.scene.addEventListener('updateFrame', this.updateFrame);
+    },
+    onTouchStart: function (ev) {
+      if (!ev.touches || ev.touches.length === 0) {
+        console.error('No touches on touch event', ev);
+        return
+      }
+      this.tapData = [
+        ev.touches[0].clientX / window.innerWidth,
+        ev.touches[0].clientY / window.innerHeight
+      ];
+    },
+    /*
+    Add a node to the scene and keep its pose updated using the anchorOffset
+    */
+
+    updateFrame: function (data) {
+      var frame = data.detail;
+      if (this.tapData !== null) {
+        var x = this.tapData[0];
+        var y = this.tapData[1];
+        this.tapData = null;
+        var self = this;
+        data.detail.findAnchor(x,y).then(function (anchorOffset) {
+          if (anchorOffset === null){
+            self.alertMessage.innerHTML = 'miss';
+          } else {
+            self.alertMessage.innerHTML = 'hit';
+            var entity = document.createElement('a-entity');
+            
+            // will set the position and orientation based on the anchorOffset attached to the entity
+            entity.setAttribute('xranchor', {});
+            entity.anchorOffset = anchorOffset;
+
+            self.el.emit('newAnchoredEntity', entity);            
+          }
+        }).catch(function (err) {
+          console.error('Error in hit test', err);
+        });
+      }
+    }
+});

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -1,0 +1,43 @@
+// assumes a property
+//  this.anchorOffset
+// will be set, containing a WebXR XRAnchorOffset 
+
+AFRAME.registerComponent('xranchor', {
+    init: function () {
+        this.anchorMatrix = new THREE.Matrix4();
+        this.positionVec3 = new THREE.Vector3();
+        this.rotationQuat = new THREE.Quaternion();
+        this.rotationVec3 = new THREE.Vector3();
+        this.el.sceneEl.addEventListener('updateFrame', this.updateFrame.bind(this));
+    },
+
+    updateFrame: function (data) {
+        var frame = data.detail;
+        var anchorOffset = this.el.anchorOffset;
+
+        if (!anchorOffset) {
+            return;
+        }
+        var anchor = frame.getAnchor(anchorOffset.anchorUID);
+        if (anchor === null) {
+          return;
+        }
+        var anchorMatrix = this.anchorMatrix.fromArray(anchorOffset.getOffsetTransform(anchor.coordinateSystem));
+        var positionVec3 = this.positionVec3.setFromMatrixPosition(anchorMatrix);
+
+        this.el.setAttribute('position', {
+          x: positionVec3.x,
+          y: positionVec3.y,
+          z: positionVec3.z
+        });
+
+        var rotationQuat = this.rotationQuat.setFromRotationMatrix(anchorMatrix);
+        var rotationVec3 = this.rotationVec3.applyQuaternion(rotationQuat);
+
+        this.el.setAttribute('rotation', {
+          x: rotationVec3.x,
+          y: rotationVec3.y,
+          z: rotationVec3.z
+        });
+      },
+});

--- a/src/index.js
+++ b/src/index.js
@@ -4,3 +4,4 @@ require('./systems/xr.js');
 
 require('./components/ar-mode-ui.js');
 require('./components/xr.js');
+require('./components/anchor.js');


### PR DESCRIPTION
created src/components/anchor.js
- the "xranchor" component assumes an XRAnchorOffset is in "el.anchorOffset" of the element it's attached to
- our "hit-test" component does this on a hit

examples/lib/hit-test.js is a simple hit-test component
examples/ar/hit_test/index.html uses both of these